### PR TITLE
fix: `strdup` is not available in `musl`

### DIFF
--- a/src/ipset.c
+++ b/src/ipset.c
@@ -6,6 +6,7 @@
 #include <libipset/session.h>
 #include <libipset/types.h>
 
+#include "utils.h"
 #include "wazuh.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
@@ -16,7 +17,7 @@ static int standard_error(struct ipset* ipset, void* p)
     enum ipset_err_type err_type  = ipset_session_report_type(session);
 
     const char* msg = ipset_session_report_msg(session);
-    char* message   = msg != nullptr ? strdup(msg) : nullptr;
+    char* message   = msg != nullptr ? utils_strdup(msg) : nullptr;
     if (message != NULL) {
         size_t len = strlen(message);
         if (len > 0 && message[len - 1] == '\n') {

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,6 +1,7 @@
 #include "utils.h"
 
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -59,4 +60,15 @@ enum ar_command utils_parse_command(const char* command)
     }
 
     return AR_COMMAND_INVALID;
+}
+
+char* utils_strdup(const char* str)
+{
+    if (str == nullptr) {
+        return nullptr;
+    }
+
+    size_t len = strlen(str);
+    char* dup  = (char*)calloc(1, len + 1);
+    return dup != nullptr ? (char*)memcpy(dup, str, len) : nullptr;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,4 +15,6 @@ enum ar_command {
 [[gnu::nonnull(1)]] const char* utils_get_list_name(const struct cJSON* input, int family);
 [[gnu::nonnull(1)]] enum ar_command utils_parse_command(const char* command);
 
+[[nodiscard]] char* utils_strdup(const char* str);
+
 #endif /* E3DBFFEA_EAB7_41DB_BEA4_D4593BF9EA05 */

--- a/src/wazuh.c
+++ b/src/wazuh.c
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 
 #include "globals.h"
+#include "utils.h"
 
 static char* log_file_name = nullptr;
 
@@ -50,7 +51,7 @@ static char* wazuh_get_home_dir()
         return nullptr;
     }
 
-    return strdup(path);
+    return utils_strdup(path);
 }
 
 static char* get_wazuh_log_file()


### PR DESCRIPTION
This pull request introduces a utility function `utils_strdup` to provide a string duplication method across the codebase. It replaces direct calls to `strdup` with `utils_strdup`, because the former is absent in `musl`. The changes also include necessary header updates to maintain proper dependencies.

**String duplication improvements:**

* Added the `utils_strdup` function in `utils.c` and its declaration in `utils.h` to safely duplicate strings, returning `nullptr` if the input is `nullptr` and allocating memory using `calloc`. [[1]](diffhunk://#diff-3e04e056edbdc0f772b0ffd1c93cef1187209f37276d40d2a281d9b989398a73R64-R74) [[2]](diffhunk://#diff-9022459f0ccbb7cf6daac6ecb5af4f37d240219981a8c23076c14c5f002f9c8cR18-R19)
* Replaced direct calls to `strdup` with `utils_strdup` in `ipset.c` and `wazuh.c` to standardize string duplication and improve safety. [[1]](diffhunk://#diff-eccce0da19d136aaf16b06e829b2d26ee6c2f6eca53dca4f07cb2f641ad96e44L19-R20) [[2]](diffhunk://#diff-0c0e41f8d177009b8d3ed3641ced5c4c73902e51989a9805c61d683c9972ca67L53-R54)

**Dependency and header management:**

* Included `utils.h` in `ipset.c` and `wazuh.c` to ensure access to the new utility function. [[1]](diffhunk://#diff-eccce0da19d136aaf16b06e829b2d26ee6c2f6eca53dca4f07cb2f641ad96e44R9) [[2]](diffhunk://#diff-0c0e41f8d177009b8d3ed3641ced5c4c73902e51989a9805c61d683c9972ca67R15)
* Added missing standard library includes in `utils.c` to support memory allocation functions.