### PR TITLE
refactor: compatibility with Debian oldoldstable

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ When in doubt, **favor clarity and explicit error paths** over cleverness.
 Follow the existing style in `src/`.
 
 - **Language level**
-  - Use C23-compatible C. It is acceptable to use C2x features supported by modern GCC/Clang (e.g., attributes, `nullptr` where already present, designated initializers).
+  - Use C23-compatible C. It is acceptable to use C2x features supported by clang 11 and gcc 10 (e.g., attributes).
   - Do **not** introduce C++ features; this is C compiled as C, even if some files use C++-style attributes.
 - **Headers and modules**
   - Add new declarations to the most appropriate existing header: `utils.h`, `json.h`, `wazuh.h`, `ipset.h`, or create a new header if strictly needed.

--- a/src/ipset.c
+++ b/src/ipset.c
@@ -17,7 +17,7 @@ static int standard_error(struct ipset* ipset, void* p)
     enum ipset_err_type err_type  = ipset_session_report_type(session);
 
     const char* msg = ipset_session_report_msg(session);
-    char* message   = msg != nullptr ? utils_strdup(msg) : nullptr;
+    char* message   = msg != NULL ? utils_strdup(msg) : NULL;
     if (message != NULL) {
         size_t len = strlen(message);
         if (len > 0 && message[len - 1] == '\n') {
@@ -29,13 +29,13 @@ static int standard_error(struct ipset* ipset, void* p)
         case IPSET_NO_ERROR:
             break;
         case IPSET_WARNING:
-            wazuh_log_message("Warning: %s", message != nullptr && *message != '\0' ? message : "Unknown warning");
+            wazuh_log_message("Warning: %s", message != NULL && *message != '\0' ? message : "Unknown warning");
             break;
         case IPSET_NOTICE:
-            wazuh_log_message("Notice: %s", message != nullptr && *message != '\0' ? message : "Unknown notice");
+            wazuh_log_message("Notice: %s", message != NULL && *message != '\0' ? message : "Unknown notice");
             break;
         case IPSET_ERROR:
-            wazuh_log_message("Error: %s", message != nullptr && *message != '\0' ? message : "Unknown error");
+            wazuh_log_message("Error: %s", message != NULL && *message != '\0' ? message : "Unknown error");
             break;
     }
 
@@ -49,13 +49,13 @@ struct ipset* ipset_initialize()
 {
     ipset_load_types();
     struct ipset* h = ipset_init();
-    if (h != nullptr) {
+    if (h != NULL) {
         ipset_custom_printf(
             h,
-            nullptr,
+            NULL,
             standard_error,
-            nullptr,
-            nullptr
+            NULL,
+            NULL
         );
     }
     else {

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -13,7 +13,7 @@ static char buf[MAX_BUF_SIZE];
 cJSON* read_and_parse()
 {
     memset(buf, 0, sizeof(buf));
-    if (fgets(buf, MAX_BUF_SIZE, stdin) == nullptr) {
+    if (fgets(buf, MAX_BUF_SIZE, stdin) == NULL) {
         wazuh_log_message("Failed to read input from stdin");
         exit(OS_FAILURE);
     }
@@ -30,7 +30,7 @@ cJSON* read_and_parse()
 
     wazuh_log_message("%s", buf);
     cJSON* json = json_parse_str(buf);
-    if (json == nullptr) {
+    if (json == NULL) {
         wazuh_log_message("Failed to parse JSON input");
         exit(OS_FAILURE);
     }
@@ -41,13 +41,13 @@ cJSON* read_and_parse()
 void send_control_message(const char* srcip)
 {
     cJSON* keys = cJSON_CreateStringArray(&srcip, 1);
-    if (keys == nullptr) {
+    if (keys == NULL) {
         wazuh_log_message("Failed to create control message keys (out of memory?)");
         exit(OS_FAILURE);
     }
 
     char* message = json_build_control_message(g_program_name, keys);
-    if (message == nullptr) {
+    if (message == NULL) {
         wazuh_log_message("Failed to build control message (out of memory?)");
         cJSON_Delete(keys);
         exit(OS_FAILURE);

--- a/src/utils.c
+++ b/src/utils.c
@@ -10,7 +10,7 @@
 
 int utils_get_ip_family(const char* ip_str)
 {
-    if (strchr(ip_str, ':') != nullptr) {
+    if (strchr(ip_str, ':') != NULL) {
         struct in6_addr addr6;
         return inet_pton(AF_INET6, ip_str, &addr6) == 1 ? 6 : -1;
     }
@@ -26,10 +26,10 @@ const char* utils_get_list_name(const struct cJSON* input, int family)
     // Will return 0 if extra_args is NULL
     int size = cJSON_GetArraySize(extra_args);
     if (size != 2) {
-        return nullptr;
+        return NULL;
     }
 
-    cJSON* value = nullptr;
+    cJSON* value = NULL;
     if (family == 4) {
         value = cJSON_GetArrayItem(extra_args, 0);
     }
@@ -64,11 +64,11 @@ enum ar_command utils_parse_command(const char* command)
 
 char* utils_strdup(const char* str)
 {
-    if (str == nullptr) {
-        return nullptr;
+    if (str == NULL) {
+        return NULL;
     }
 
     size_t len = strlen(str);
     char* dup  = (char*)calloc(1, len + 1);
-    return dup != nullptr ? (char*)memcpy(dup, str, len) : nullptr;
+    return dup != NULL ? (char*)memcpy(dup, str, len) : NULL;
 }

--- a/src/wazuh.c
+++ b/src/wazuh.c
@@ -14,7 +14,7 @@
 #include "globals.h"
 #include "utils.h"
 
-static char* log_file_name = nullptr;
+static char* log_file_name = NULL;
 
 static char* get_timestamp(time_t time, size_t buf_size, char (*buf)[buf_size])
 {
@@ -33,22 +33,22 @@ static char* get_timestamp(time_t time, size_t buf_size, char (*buf)[buf_size])
 static char* wazuh_get_home_dir()
 {
     const struct passwd* pw = getpwnam("wazuh");
-    char* path = nullptr;
-    if (pw != nullptr && pw->pw_dir != nullptr) {
+    char* path = NULL;
+    if (pw != NULL && pw->pw_dir != NULL) {
         path = pw->pw_dir;
     }
     else {
         path = getenv("WAZUH_HOME");
     }
 
-    if (path == nullptr || path[0] == '\0') {
+    if (path == NULL || path[0] == '\0') {
         path = "/var/ossec";
     }
 
     struct stat sb;
     int rc = stat(path, &sb);
     if (rc != 0 || !S_ISDIR(sb.st_mode)) {
-        return nullptr;
+        return NULL;
     }
 
     return utils_strdup(path);
@@ -57,14 +57,14 @@ static char* wazuh_get_home_dir()
 static char* get_wazuh_log_file()
 {
     char* home_dir = wazuh_get_home_dir();
-    if (home_dir == nullptr) {
-        return nullptr;
+    if (home_dir == NULL) {
+        return NULL;
     }
 
     char* log_path = calloc(1, PATH_MAX);
-    if (log_path == nullptr) {
+    if (log_path == NULL) {
         free(home_dir);
-        return nullptr;
+        return NULL;
     }
 
     snprintf(log_path, PATH_MAX, "%s/logs/active-responses.log", home_dir);
@@ -74,31 +74,31 @@ static char* get_wazuh_log_file()
 
 void wazuh_initialize()
 {
-    if (log_file_name == nullptr) {
+    if (log_file_name == NULL) {
         log_file_name = get_wazuh_log_file();
     }
 }
 
 void wazuh_finalize()
 {
-    if (log_file_name != nullptr) {
+    if (log_file_name != NULL) {
         free(log_file_name);
-        log_file_name = nullptr;
+        log_file_name = NULL;
     }
 }
 
 void wazuh_log_message(const char* format, ...)
 {
     char timestamp[sizeof("YYYY/MM/DD HH:MM:SS")];
-    const time_t now = time(nullptr);
+    const time_t now = time(NULL);
     get_timestamp(now, sizeof(timestamp), &timestamp);
 
-    FILE* f = nullptr;
-    if (log_file_name != nullptr) {
+    FILE* f = NULL;
+    if (log_file_name != NULL) {
         f = fopen(log_file_name, "a");
     }
 
-    FILE* stream = f != nullptr ? f : stderr;
+    FILE* stream = f != NULL ? f : stderr;
 
     fprintf(stream, "%s %s: ", timestamp, g_program_name);
 
@@ -111,7 +111,7 @@ void wazuh_log_message(const char* format, ...)
 
     fflush(stream);
 
-    if (f != nullptr) {
+    if (f != NULL) {
         fclose(f);
     }
 }


### PR DESCRIPTION
This pull request standardizes the use of `NULL` instead of `nullptr` throughout the C codebase, ensuring better compatibility with C23 and older C standards. Additionally, it clarifies the coding guidelines to specify which compiler versions support acceptable C2x features.

Standardization of null pointer usage:

* Replaced all occurrences of `nullptr` with `NULL` in the C source files (`src/ipset.c`, `src/protocol.c`, `src/utils.c`, `src/wazuh.c`) to adhere to C standards and improve portability. [[1]](diffhunk://#diff-eccce0da19d136aaf16b06e829b2d26ee6c2f6eca53dca4f07cb2f641ad96e44L20-R20) [[2]](diffhunk://#diff-eccce0da19d136aaf16b06e829b2d26ee6c2f6eca53dca4f07cb2f641ad96e44L32-R38) [[3]](diffhunk://#diff-eccce0da19d136aaf16b06e829b2d26ee6c2f6eca53dca4f07cb2f641ad96e44L52-R58) [[4]](diffhunk://#diff-0b6794e089b51873f4effd373d78e8d13d1ee1ca83c0dd1394b09bcad26254c7L16-R16) [[5]](diffhunk://#diff-0b6794e089b51873f4effd373d78e8d13d1ee1ca83c0dd1394b09bcad26254c7L33-R33) [[6]](diffhunk://#diff-0b6794e089b51873f4effd373d78e8d13d1ee1ca83c0dd1394b09bcad26254c7L44-R50) [[7]](diffhunk://#diff-3e04e056edbdc0f772b0ffd1c93cef1187209f37276d40d2a281d9b989398a73L13-R13) [[8]](diffhunk://#diff-3e04e056edbdc0f772b0ffd1c93cef1187209f37276d40d2a281d9b989398a73L29-R32) [[9]](diffhunk://#diff-3e04e056edbdc0f772b0ffd1c93cef1187209f37276d40d2a281d9b989398a73L67-R73) [[10]](diffhunk://#diff-0c0e41f8d177009b8d3ed3641ced5c4c73902e51989a9805c61d683c9972ca67L17-R17) [[11]](diffhunk://#diff-0c0e41f8d177009b8d3ed3641ced5c4c73902e51989a9805c61d683c9972ca67L36-R51) [[12]](diffhunk://#diff-0c0e41f8d177009b8d3ed3641ced5c4c73902e51989a9805c61d683c9972ca67L60-R67) [[13]](diffhunk://#diff-0c0e41f8d177009b8d3ed3641ced5c4c73902e51989a9805c61d683c9972ca67L77-R101) [[14]](diffhunk://#diff-0c0e41f8d177009b8d3ed3641ced5c4c73902e51989a9805c61d683c9972ca67L114-R114)

Documentation update:

* Updated `.github/copilot-instructions.md` to clarify that only C2x features supported by clang 11 and gcc 10 are acceptable, removing references to `nullptr` as an example.