### PR TITLE
ci: add Docker build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!src
+!CMakeLists.txt

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@e61617a16c407a86262fb923c35a616ddbe070b3 # v4.6.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build
+        uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6.10.0
+        with:
+          source: .
+          files: docker-bake.hcl
+          no-cache: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+
+      - name: Upload artirfacts (amd64)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: amd64
+          path: out/linux_amd64
+
+      - name: Upload artirfacts (arm64)
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: arm64
+          path: out/linux_arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.cache/
 /build/
+/out/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+FROM --platform=${BUILDPLATFORM} tonistiigi/xx:latest@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
+
+FROM --platform=${BUILDPLATFORM} alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375 AS build-alpine
+ARG TARGETPLATFORM
+COPY --from=xx / /
+RUN \
+    apk add --no-cache clang llvm lld make cmake file pkgconf && \
+    xx-apk add --no-cache cjson-dev cjson-static gcc ipset-dev libmnl-static musl-dev
+
+WORKDIR /src
+COPY . .
+
+RUN \
+    set -x && \
+    export ARCHITECTURE=$(xx-info alpine-arch) && \
+    export XX_CC_PREFER_LINKER=ld && \
+    export SYSROOT=$(xx-info sysroot) && \
+    export HOSTSPEC=$(xx-info triple) && \
+    xx-clang --setup-target-triple && \
+    cmake -S . -B build $(xx-clang --print-cmake-defines) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_STATIC=on && \
+    cmake --build build -j 2 && \
+    ${HOSTSPEC}-strip build/firewall-ipset && \
+    install -D -m 0755 build/firewall-ipset /static/firewall-ipset
+
+FROM --platform=${BUILDPLATFORM} debian:oldoldstable-slim@sha256:cd8337fce79b42c82629c45e422a81c3461ae09f9c93afd47c56384ae9dcbed6 AS build-debian
+ARG TARGETPLATFORM
+COPY --from=xx / /
+RUN \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates clang curl llvm lld make file pkgconf && \
+    xx-apt-get install -y --no-install-recommends gcc libc6-dev libcjson-dev libipset-dev && \
+    apt-get clean && xx-apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+RUN \
+    xx-clang --setup-target-triple && \
+    curl -fsSL https://github.com/Kitware/CMake/releases/download/v4.2.1/cmake-4.2.1-linux-$(arch).sh > cmake-install.sh && \
+    chmod +x cmake-install.sh && \
+    ./cmake-install.sh --skip-license --prefix=/usr/local && \
+    rm cmake-install.sh
+
+WORKDIR /src
+COPY . .
+
+RUN \
+    set -x && \
+    export ARCHITECTURE=$(xx-info alpine-arch) && \
+    export XX_CC_PREFER_LINKER=ld && \
+    export SYSROOT=$(xx-info sysroot) && \
+    export HOSTSPEC=$(xx-info triple) && \
+    xx-clang --setup-target-triple && \
+    cmake -S . -B build $(xx-clang --print-cmake-defines) -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_STATIC=off && \
+    cmake --build build -j 2 && \
+    ${HOSTSPEC}-strip build/firewall-ipset && \
+    install -D -m 0755 build/firewall-ipset /dynamic/firewall-ipset
+
+FROM scratch
+ARG TARGETARCH
+COPY --from=build-alpine /static /static
+COPY --from=build-debian /dynamic /dynamic

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,16 @@
+target "default" {
+  dockerfile = "Dockerfile"
+  platforms  = ["linux/amd64", "linux/arm64"]
+  pull       = true
+  output = [
+    "type=local,dest=out",
+  ]
+
+  cache-from = [
+    "type=gha"
+  ]
+
+  cache-to = [
+    "type=gha,mode=max"
+  ]
+}


### PR DESCRIPTION
This pull request introduces a comprehensive Docker build system for the project, enabling multi-platform builds and automated CI workflows. The changes include a new `Dockerfile` for building static and dynamic binaries, a Docker Bake configuration for reproducible builds, a GitHub Actions workflow for CI/CD, and updates to `.dockerignore` to optimize Docker context.

**Docker build and CI infrastructure:**

* Added a multi-stage `Dockerfile` that builds both static and dynamic versions of the `firewall-ipset` binary for multiple platforms (Alpine and Debian), using cross-compilation tools and CMake.
* Introduced a `docker-bake.hcl` file to define build targets, platforms (`linux/amd64`, `linux/arm64`), and caching strategies for efficient and reproducible builds.
* Created a `.github/workflows/docker.yml` GitHub Actions workflow to automate Docker image builds and pushes on push, pull request, and manual triggers, leveraging Docker Buildx and Bake.

**Build context and performance improvements:**

* Updated `.dockerignore` to exclude all files except the `src` directory and `CMakeLists.txt`, reducing build context size and improving Docker build performance.